### PR TITLE
mds/scrub: skip backtrace scrub for inode 0x1

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4684,8 +4684,9 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       if (results->backtrace.ondisk_read_retval != 0) {
         results->backtrace.error_str << "failed to read off disk; see retval";
         // we probably have a new unwritten file!
+        // or backtrace for root inode (inode 0x1) doesn't make sense
         // so skip the backtrace scrub for this entry and say that all's well
-        if (in->is_dirty_parent()) {
+        if (in->is_dirty_parent() || in->ino() == MDS_INO_ROOT) {
           dout(20) << "forcing backtrace as passed since inode is dirty parent" << dendl;
           results->backtrace.passed = true;
         }
@@ -4708,8 +4709,9 @@ void CInode::validate_disk_state(CInode::validated_data *results,
         results->backtrace.error_str << "failed to decode on-disk backtrace ("
                                      << bl.length() << " bytes)!";
         // we probably have a new unwritten file!
+        // or backtrace for root inode (inode 0x1) doesn't make sense
         // so skip the backtrace scrub for this entry and say that all's well
-        if (in->is_dirty_parent()) {
+        if (in->is_dirty_parent() || in->ino() == MDS_INO_ROOT) {
           dout(20) << "decode failed; forcing backtrace as passed since "
                       "inode is dirty parent" << dendl;
           results->backtrace.passed = true;


### PR DESCRIPTION
Since a backtrace for inode 0x1 doesn't exist and doesn't make sense it is wise to skip this inode and declare it as passed.

Fixes: https://tracker.ceph.com/issues/50976





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
